### PR TITLE
filling new buffer with 0's and bit order change.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,14 +15,14 @@ function BitField(data){
 }
 
 BitField.prototype.get = function(i){
-	return !!(this.buffer[i >> 3] & (1 << (i % 8)));
+	return !!(this.buffer[i >> 3] & (128 >> (i % 8)));
 };
 
 BitField.prototype.set = function(i, b){
 	if(b || arguments.length === 1){
-		this.buffer[i >> 3] |= 1 << (i % 8);
+		this.buffer[i >> 3] |= 128 >> (i % 8);
 	} else {
-		this.buffer[i >> 3] &= ~(1 << (i % 8));
+		this.buffer[i >> 3] &= ~(128 >> (i % 8));
 	}
 };
 


### PR DESCRIPTION
[d085132](https://github.com/mafintosh/BitField/commit/d0851327f7f030a1615e9710f1182afe2b30de23) fixes an issue when using `new BitField(number)` where we needed to fill the node buffer with 0's (contains random garbage otherwise).

[0f05295](https://github.com/mafintosh/BitField/commit/0f05295fc3333165f836ddc9106576a89fc29a94) changes the ordering of bits to left-to-right instead of right-to-left. This makes BitField compliant with the BitTorrent spec (which I'm currently implementing).

Fell free to cherry-pick the first commit if you don't want to change the ordering
