### PR TITLE
Important fix for bitfields of non-multiple-of-8 length

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function BitField(data, opts){
 	this.grow = opts && (isFinite(opts.grow) && getByteSize(opts.grow) || opts.grow) || 0;
 
 	if(typeof data === "number" || data === undefined){
-		if(data % 8 !== 0) data += 1 << 3;
+        while (data % 8 !== 0) ++data;
 		data = new Container(getByteSize(data));
 		if(data.fill) data.fill(0); // clear node buffers of garbage
 	}


### PR DESCRIPTION
Previously a buffer of say size 13 would incorrectly yield a 3-byte bitfield, whereas with this change it correctly yields a 2-byte bitfield by rounding up to the next multiple of 8 as opposed to naively adding 8 and then rounding up.  This change has very important correctness implications for implementing bittorrent because if a client building off of bitfield sends a bitfield message with the wrong size, existing clients will realize the error and kill the connection as per the unofficial spec.
