### PR TITLE
double buffer on growth

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ BitField.prototype.get = function(i){
 BitField.prototype.set = function(i, b){
 	var j = i >> 3;
 	if (b || arguments.length === 1){
-		this._grow(j + 1);
+		if (this.buffer.length < j + 1) this._grow(Math.max(j + 1, Math.min(2 * this.buffer.length, this.grow)));
 		// Set
 		this.buffer[j] |= 128 >> (i % 8);
 	} else if (j < this.buffer.length) {
@@ -48,8 +48,11 @@ BitField.prototype._grow = function(length) {
 	if (this.buffer.length < length && length <= this.grow) {
 		var newBuffer = new Container(length);
 		if (newBuffer.fill) newBuffer.fill(0);
-		for(var i = 0; i < this.buffer.length; i++) {
-			newBuffer[i] = this.buffer[i];
+		if (this.buffer.copy) this.buffer.copy(newBuffer, 0);
+		else {
+			for(var i = 0; i < this.buffer.length; i++) {
+				newBuffer[i] = this.buffer[i];
+			}
 		}
 		this.buffer = newBuffer;
 	}

--- a/tests.js
+++ b/tests.js
@@ -65,7 +65,7 @@ test("should be able to grow to infinity", function(t){
 		t.equal(growField.buffer.length, oldLength, "should not have grown for get()");
 		growField.set(index, true);
 		var newLength = Math.ceil((index + 1) / 8);
-		t.equal(growField.buffer.length, newLength, "should have grown for set()");
+		t.ok(growField.buffer.length >= newLength, "should have grown for set()");
 		t.strictEqual(growField.get(index), true);
 	}
 
@@ -79,7 +79,7 @@ test("should restrict growth to growth option", function(t){
 		var oldLength = smallGrowField.buffer.length;
 		smallGrowField.set(i, true);
 		if (i <= 55) {
-			t.equal(smallGrowField.buffer.length, (i >> 3) + 1, "should have grown for set()");
+			t.ok(smallGrowField.buffer.length >= (i >> 3) + 1, "should have grown for set()");
 			t.strictEqual(smallGrowField.get(i), true);
 		} else {
 			t.equal(smallGrowField.buffer.length, oldLength, "should not have grown for set()");


### PR DESCRIPTION
instead of growing to *just* being able to contain the value that didn't fit just double the buffer size.
this results in way fewer copies if you insert stuff in the beginning of the bitfield instead of the end.

this pr also uses `.copy` (if available) to copy the buffer since thats a lot faster than manually copying everything in a for loop