### PR TITLE
Upgrade to es6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,63 +1,38 @@
-var Container = typeof Buffer !== 'undefined'
-  ? Buffer // in node, use buffers
-  : Uint8Array // in browsers, use typed arrays
-
-function BitField (data, opts) {
-  if (!(this instanceof BitField)) {
-    return new BitField(data, opts)
-  }
-
-  if (arguments.length === 0) {
-    data = 0
-  }
-
-  this.grow = (opts && ((isFinite(opts.grow) && getByteSize(opts.grow)) || opts.grow)) || 0
-
-  if (typeof data === 'number' || data === undefined) {
-    data = new Container(getByteSize(data)) // eslint-disable-line node/no-deprecated-api
-    if (data.fill && !data._isBuffer) data.fill(0) // clear node buffers of garbage
-  }
-  this.buffer = data
-}
-
 function getByteSize (num) {
-  var out = num >> 3
+  let out = num >> 3
   if (num % 8 !== 0) out++
   return out
 }
 
-BitField.prototype.get = function (i) {
-  var j = i >> 3
-  return (j < this.buffer.length) &&
-    !!(this.buffer[j] & (128 >> (i % 8)))
-}
-
-BitField.prototype.set = function (i, b) {
-  var j = i >> 3
-  if (b || arguments.length === 1) {
-    if (this.buffer.length < j + 1) {
-      this._grow(Math.max(j + 1, Math.min(2 * this.buffer.length, this.grow)))
-    }
-    // Set
-    this.buffer[j] |= 128 >> (i % 8)
-  } else if (j < this.buffer.length) {
-    // Clear
-    this.buffer[j] &= ~(128 >> (i % 8))
+class BitField {
+  constructor (data = 0, { grow } = {}) {
+    this.grow = (grow && isFinite(grow) && getByteSize(grow)) || grow || 0
+    this.buffer = typeof data === 'number' ? new Uint8Array(getByteSize(data)) : data
   }
-}
 
-BitField.prototype._grow = function (length) {
-  if (this.buffer.length < length && length <= this.grow) {
-    var newBuffer = new Container(length) // eslint-disable-line node/no-deprecated-api
-    if (newBuffer.fill) newBuffer.fill(0)
-    if (this.buffer.copy) {
-      this.buffer.copy(newBuffer, 0)
-    } else {
-      for (var i = 0; i < this.buffer.length; i++) {
-        newBuffer[i] = this.buffer[i]
+  get (i) {
+    const j = i >> 3
+    return (j < this.buffer.length) &&
+      !!(this.buffer[j] & (128 >> (i % 8)))
+  }
+
+  set (i, b = 1) {
+    const j = i >> 3
+    if (b) {
+      if (this.buffer.length < j + 1) {
+        const length = Math.max(j + 1, Math.min(2 * this.buffer.length, this.grow))
+        if (length <= this.grow) {
+          const newBuffer = new Uint8Array(length)
+          newBuffer.set(this.buffer)
+          this.buffer = newBuffer
+        }
       }
+      // Set
+      this.buffer[j] |= 128 >> (i % 8)
+    } else if (j < this.buffer.length) {
+      // Clear
+      this.buffer[j] &= ~(128 >> (i % 8))
     }
-    this.buffer = newBuffer
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class BitField {
       !!(this.buffer[j] & (128 >> (i % 8)))
   }
 
-  set (i, b = 1) {
+  set (i, b = true) {
     const j = i >> 3
     if (b) {
       if (this.buffer.length < j + 1) {


### PR DESCRIPTION
it's only using Uint8Array now. (less memory and ~17% faster then Buffer)
it's no longer possible to use Bitfield without `new` keyword

Not sure if it would impact other modules if they are using something like `Buffer.isBuffer()` checks when passing there bitfield around to other peers or if something else would break due to new es6 syntax (Maybe reason to why a major bump would be in order?)