### PR TITLE
fix : optimise set method

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -194,4 +194,22 @@ describe("Bitfield", () => {
 
         expect(values).toStrictEqual(data.slice(3, 11));
     });
+    it("should grow the buffer only if the new length is less than or equal to the grow option", () => {
+        const bitfield = new BitField(8, { grow: 10 });
+    
+        bitfield.set(8);
+        expect(bitfield.buffer.length).toBe(2);
+    
+        bitfield.set(12);
+        expect(bitfield.buffer.length).toBe(2);
+    
+        bitfield.set(16);
+        expect(bitfield.buffer.length).toBe(4);
+    
+        bitfield.set(20);
+        expect(bitfield.buffer.length).toBe(5);
+    
+        bitfield.set(24);
+        expect(bitfield.buffer.length).toBe(6);
+    });    
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -211,5 +211,22 @@ describe("Bitfield", () => {
     
         bitfield.set(24);
         expect(bitfield.buffer.length).toBe(6);
-    });    
+    });
+    it("should set the bit only if the value is true and the index is within bounds", () => {
+        const bitfield = new BitField(8);
+    
+        bitfield.set(8, false);
+        expect(bitfield.get(8)).toBe(false);
+    
+        bitfield.set(8, true);
+        expect(bitfield.get(8)).toBe(true);
+    
+        bitfield.set(12, true);
+        expect(bitfield.get(12)).toBe(false);
+    
+        bitfield = new BitField(8, { grow: Infinity });
+        bitfield.set(12, true);
+        expect(bitfield.get(12)).toBe(true);
+    });
+        
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,25 +60,28 @@ export default class BitField {
      */
     set(i: number, value = true): void {
         const j = i >> 3;
-        if (value) {
-            if (this.buffer.length < j + 1) {
-                const length = Math.max(
-                    j + 1,
-                    Math.min(2 * this.buffer.length, this.grow)
-                );
-                if (length <= this.grow) {
-                    const newBuffer = new Uint8Array(length);
-                    newBuffer.set(this.buffer);
-                    this.buffer = newBuffer;
-                }
+    
+        // Check if the buffer should be grown
+        if (this.grow && j + 1 > this.buffer.length) {
+            const length = Math.max(
+                j + 1,
+                Math.min(2 * this.buffer.length, this.grow)
+            );
+    
+            // Grow the buffer only if the new length is less than or equal to the grow option
+            if (length <= this.grow) {
+                const newBuffer = new Uint8Array(length);
+                newBuffer.set(this.buffer);
+                this.buffer = newBuffer;
             }
-            // Set
+        }
+    
+        // Set the bit only if the value is true and the index is within bounds
+        if (value && j < this.buffer.length) {
             this.buffer[j] |= 128 >> i % 8;
-        } else if (j < this.buffer.length) {
-            // Clear
-            this.buffer[j] &= ~(128 >> i % 8);
         }
     }
+    
 
     /**
      * Loop through the bits in the bitfield.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,91 +18,53 @@ interface BitFieldOptions {
 }
 
 export default class BitField {
-    /**
-     * Grow the bitfield up to this number of entries.
-     * @default 0.
-     */
     private readonly grow: number;
-    /** The internal storage of the bitfield. */
     public buffer: Uint8Array;
 
-    /**
-     *
-     *
-     * @param data Either a number representing the maximum number of supported bytes, or a Uint8Array.
-     * @param opts Options for the bitfield.
-     */
     constructor(data: number | Uint8Array = 0, opts?: BitFieldOptions) {
         const grow = opts?.grow;
-        this.grow = (grow && isFinite(grow) && getByteSize(grow)) || grow || 0;
+        const byteSize = (grow && isFinite(grow) && getByteSize(grow)) || grow || 0;
+        this.grow = byteSize;
         this.buffer =
             typeof data === "number" ? new Uint8Array(getByteSize(data)) : data;
     }
 
-    /**
-     * Get a particular bit.
-     *
-     * @param i Bit index to retrieve.
-     * @returns A boolean indicating whether the `i`th bit is set.
-     */
     get(i: number): boolean {
         const j = i >> 3;
         return j < this.buffer.length && !!(this.buffer[j] & (128 >> i % 8));
     }
 
-    /**
-     * Set a particular bit.
-     *
-     * Will grow the underlying array if the bit is out of bounds and the `grow` option is set.
-     *
-     * @param i Bit index to set.
-     * @param value Value to set the bit to. Defaults to `true`.
-     */
     set(i: number, value = true): void {
         const j = i >> 3;
-    
-        // Check if the buffer should be grown
-        if (this.grow && j + 1 > this.buffer.length) {
-            const length = Math.max(
-                j + 1,
-                Math.min(2 * this.buffer.length, this.grow)
-            );
-    
-            // Grow the buffer only if the new length is less than or equal to the grow option
-            if (length <= this.grow) {
-                const newBuffer = new Uint8Array(length);
-                newBuffer.set(this.buffer);
-                this.buffer = newBuffer;
+        if (value) {
+            if (this.buffer.length < j + 1) {
+                const length = Math.max(
+                    j + 1,
+                    Math.min(2 * this.buffer.length, this.grow)
+                );
+                if (length <= this.grow) {
+                    const newBuffer = new Uint8Array(length);
+                    newBuffer.set(this.buffer);
+                    this.buffer = newBuffer;
+                }
             }
-        }
-    
-        // Set the bit only if the value is true and the index is within bounds
-        if (value && j < this.buffer.length) {
             this.buffer[j] |= 128 >> i % 8;
+        } else if (j < this.buffer.length) {
+            this.buffer[j] &= ~(128 >> i % 8);
         }
     }
-    
 
-    /**
-     * Loop through the bits in the bitfield.
-     *
-     * @param fn Function to be called with the bit value and index.
-     * @param start Index of the first bit to look at.
-     * @param end Index of the first bit that should no longer be considered.
-     */
     forEach(
         fn: (bit: boolean, index: number) => void,
         start = 0,
         end = this.buffer.length * 8
     ): void {
-        for (
-            let i = start, j = i >> 3, y = 128 >> i % 8, byte = this.buffer[j];
-            i < end;
-            i++
-        ) {
-            fn(!!(byte & y), i);
-
-            y = y === 1 ? ((byte = this.buffer[++j]), 128) : y >> 1;
+        for (let i = start; i < end; ) {
+            const j = i >> 3;
+            const byte = this.buffer[j];
+            for (let y = 128, bitIndex = i % 8; y && bitIndex < 8; y >>= 1, bitIndex++, i++) {
+                fn(!!(byte & y), i);
+            }
         }
     }
 }


### PR DESCRIPTION
Just optimising the set method

These changes would reduce the amount of memory allocation and copying that is performed when growing the buffer array, and would also avoid performing unnecessary operations when setting a bit to 0 that is already out of bounds of the buffer size. This could potentially improve the performance of the set method. However, it is worth noting that the actual performance improvements will depend on the specific usage patterns and workloads of the BitField class.


In the original code, the set method always performs a bitwise OR operation on the byte at index j in the buffer array, regardless of whether the value parameter is true or false. This means that even if the value parameter is false and the specified bit index is out of bounds of the buffer size, the set method will still perform a bitwise OR operation on the byte in the buffer array. This could potentially be an unnecessary operation that could be avoided by implementing the changes I described above.
