### PR TITLE
Add isEmpty utility method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bitfield",
     "description": "a simple bitfield, compliant with the BitTorrent spec",
-    "version": "4.1.1",
+    "version": "4.2.0",
     "author": "Felix Boehm <me@feedic.com>",
     "funding": {
         "url": "https://github.com/sponsors/fb55"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bitfield",
     "description": "a simple bitfield, compliant with the BitTorrent spec",
-    "version": "4.2.0",
+    "version": "4.1.0",
     "author": "Felix Boehm <me@feedic.com>",
     "funding": {
         "url": "https://github.com/sponsors/fb55"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bitfield",
     "description": "a simple bitfield, compliant with the BitTorrent spec",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "author": "Felix Boehm <me@feedic.com>",
     "funding": {
         "url": "https://github.com/sponsors/fb55"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -303,4 +303,35 @@ describe("Bitfield", () => {
             expect(field.getSetBitCount()).toBe(0); // No bits are set
         });
     });
+
+    describe("`getAllSetIndices`", () => {
+        it("should return all indices of set bits", () => {
+            const field = new BitField(data.length);
+            data.forEach((bit, index) => {
+                if (bit) field.set(index);
+            });
+
+            const setIndices = field.getAllSetIndices();
+            const expectedIndices = data
+                .map((bit, index) => (bit ? index : -1))
+                .filter((index) => index !== -1);
+
+            expect(setIndices).toEqual(expectedIndices);
+        });
+
+        it("should return an empty array for a new BitField", () => {
+            const field = new BitField(data.length);
+            expect(field.getAllSetIndices()).toEqual([]);
+        });
+
+        it("should update correctly when bits are cleared", () => {
+            const field = new BitField(data.length);
+            field.set(2);
+            field.set(4);
+            field.set(2, false); // Clear the 3rd bit
+
+            const setIndices = field.getAllSetIndices();
+            expect(setIndices).toEqual([4]);
+        });
+    });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -240,4 +240,24 @@ describe("Bitfield", () => {
             expect(values).toStrictEqual(data.slice(3, 11));
         });
     });
+
+    describe("`isEmpty`", () => {
+        it("should return true for an empty BitField", () => {
+            const field = new BitField(10); // Assuming this creates a BitField with 10 bits, all unset
+            expect(field.isEmpty()).toBe(true);
+        });
+
+        it("should return false for a BitField with at least one bit set", () => {
+            const field = new BitField(10);
+            field.set(5); // Set the 6th bit
+            expect(field.isEmpty()).toBe(false);
+        });
+
+        it("should return true for a BitField with all bits unset after some were set", () => {
+            const field = new BitField(10);
+            field.set(3);
+            field.set(3, false); // Unset the 4th bit
+            expect(field.isEmpty()).toBe(true);
+        });
+    });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -260,4 +260,47 @@ describe("Bitfield", () => {
             expect(field.isEmpty()).toBe(true);
         });
     });
+
+    describe("`BitField` bit count", () => {
+        it("should correctly count the number of set bits", () => {
+            const field = new BitField(16); // A BitField with 16 bits
+            field.set(3); // Set the 4th bit
+            field.set(7); // Set the 8th bit
+
+            expect(field.getSetBitCount()).toBe(2);
+        });
+
+        it("should decrease count when bits are cleared", () => {
+            const field = new BitField(16);
+            field.set(2);
+            field.set(4);
+            field.set(2, false); // Clear the 3rd bit
+
+            expect(field.getSetBitCount()).toBe(1);
+        });
+
+        it("should handle setting multiple bits with `setAll`", () => {
+            const field = new BitField(16);
+            const data = [true, false, true, true]; // Array of bit values
+            field.setAll(data); // Set multiple bits at once
+
+            expect(field.getSetBitCount()).toBe(3); // 3 bits are set to true
+        });
+
+        it("should handle setting and clearing bits with `setAll`", () => {
+            const field = new BitField(16);
+            field.set(1);
+            field.set(3);
+            const data = [true, false, false, true]; // Array of bit values
+            field.setAll(data, 2); // Start setting from the 3rd bit
+
+            expect(field.getSetBitCount()).toBe(3); // 3 bits are set to true
+        });
+
+        it("should correctly count bits when the bitfield is empty", () => {
+            const field = new BitField(16);
+
+            expect(field.getSetBitCount()).toBe(0); // No bits are set
+        });
+    });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -27,6 +27,7 @@ describe("Bitfield", () => {
 
         it("correct size bitfield", () => {
             expect(new BitField(1).buffer).toHaveLength(1);
+            expect(new BitField(1)).toHaveLength(8);
             expect(new BitField(2).buffer).toHaveLength(1);
             expect(new BitField(3).buffer).toHaveLength(1);
             expect(new BitField(4).buffer).toHaveLength(1);
@@ -43,6 +44,7 @@ describe("Bitfield", () => {
             expect(new BitField(15).buffer).toHaveLength(2);
             expect(new BitField(16).buffer).toHaveLength(2);
             expect(new BitField(17).buffer).toHaveLength(3);
+            expect(new BitField(17)).toHaveLength(24);
         });
     });
 
@@ -258,80 +260,6 @@ describe("Bitfield", () => {
             field.set(3);
             field.set(3, false); // Unset the 4th bit
             expect(field.isEmpty()).toBe(true);
-        });
-    });
-
-    describe("`BitField` bit count", () => {
-        it("should correctly count the number of set bits", () => {
-            const field = new BitField(16); // A BitField with 16 bits
-            field.set(3); // Set the 4th bit
-            field.set(7); // Set the 8th bit
-
-            expect(field.getSetBitCount()).toBe(2);
-        });
-
-        it("should decrease count when bits are cleared", () => {
-            const field = new BitField(16);
-            field.set(2);
-            field.set(4);
-            field.set(2, false); // Clear the 3rd bit
-
-            expect(field.getSetBitCount()).toBe(1);
-        });
-
-        it("should handle setting multiple bits with `setAll`", () => {
-            const field = new BitField(16);
-            const data = [true, false, true, true]; // Array of bit values
-            field.setAll(data); // Set multiple bits at once
-
-            expect(field.getSetBitCount()).toBe(3); // 3 bits are set to true
-        });
-
-        it("should handle setting and clearing bits with `setAll`", () => {
-            const field = new BitField(16);
-            field.set(1);
-            field.set(3);
-            const data = [true, false, false, true]; // Array of bit values
-            field.setAll(data, 2); // Start setting from the 3rd bit
-
-            expect(field.getSetBitCount()).toBe(3); // 3 bits are set to true
-        });
-
-        it("should correctly count bits when the bitfield is empty", () => {
-            const field = new BitField(16);
-
-            expect(field.getSetBitCount()).toBe(0); // No bits are set
-        });
-    });
-
-    describe("`getAllSetIndices`", () => {
-        it("should return all indices of set bits", () => {
-            const field = new BitField(data.length);
-            data.forEach((bit, index) => {
-                if (bit) field.set(index);
-            });
-
-            const setIndices = field.getAllSetIndices();
-            const expectedIndices = data
-                .map((bit, index) => (bit ? index : -1))
-                .filter((index) => index !== -1);
-
-            expect(setIndices).toEqual(expectedIndices);
-        });
-
-        it("should return an empty array for a new BitField", () => {
-            const field = new BitField(data.length);
-            expect(field.getAllSetIndices()).toEqual([]);
-        });
-
-        it("should update correctly when bits are cleared", () => {
-            const field = new BitField(data.length);
-            field.set(2);
-            field.set(4);
-            field.set(2, false); // Clear the 3rd bit
-
-            const setIndices = field.getAllSetIndices();
-            expect(setIndices).toEqual([4]);
         });
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,4 +162,18 @@ export default class BitField {
             }
         }
     }
+
+    /**
+     * Check if all bits in the Bitfield are unset.
+     *
+     * @returns A boolean indicating whether all bits are unset.
+     */
+    isEmpty(): boolean {
+        for (let i = 0; i < this.buffer.length; i++) {
+            if (this.buffer[i] !== 0) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,6 @@ export default class BitField {
         return this.buffer.length << 3;
     }
 
-    /** Variable to store the count of bits set to 1 */
-    private setBitCount: number = 0;
-
-    /** Set to keep track of indices of set bits */
-    private readonly setBits: Set<number> = new Set();
-
     /**
      * Constructs a BitField.
      *
@@ -57,19 +51,6 @@ export default class BitField {
             : 0;
         this.buffer =
             typeof data === "number" ? new Uint8Array(bitsToBytes(data)) : data;
-        this.initializeSetBits();
-    }
-
-    /**
-     * Initialize the set bits based on current buffer data.
-     */
-    private initializeSetBits(): void {
-        for (let i = 0; i < this.length; i++) {
-            if (this.get(i)) {
-                this.setBits.add(i);
-                this.setBitCount++;
-            }
-        }
     }
 
     /**
@@ -96,13 +77,8 @@ export default class BitField {
      */
     set(bitIndex: number, value = true): void {
         const byteIndex = bitIndex >> 3;
-        const bitWasSet = this.get(bitIndex);
 
         if (value) {
-            if (!bitWasSet) {
-                this.setBitCount++;
-                this.setBits.add(bitIndex);
-            }
             if (byteIndex >= this.buffer.length) {
                 const newLength = Math.max(
                     byteIndex + 1,
@@ -116,21 +92,8 @@ export default class BitField {
             }
             this.buffer[byteIndex] |= 0b1000_0000 >> bitIndex % 8;
         } else if (byteIndex < this.buffer.length) {
-            if (bitWasSet) {
-                this.setBitCount--;
-                this.setBits.delete(bitIndex);
-            }
             this.buffer[byteIndex] &= ~(0b1000_0000 >> bitIndex % 8);
         }
-    }
-
-    /**
-     * Get all indices of bits that are set.
-     *
-     * @returns An array of indices where bits are set.
-     */
-    getAllSetIndices(): number[] {
-        return Array.from(this.setBits);
     }
 
     /**
@@ -154,15 +117,6 @@ export default class BitField {
         let byteIndex = offset >> 3;
         let bitMask = 0b1000_0000 >> offset % 8;
         for (let index = 0; index < array.length; index++) {
-            const bitIndex = offset + index;
-            const bitWasSet = this.get(bitIndex);
-            const bitValue = array[index];
-
-            if (bitValue && !bitWasSet) {
-                this.setBitCount++;
-            } else if (!bitValue && bitWasSet) {
-                this.setBitCount--;
-            }
             if (array[index]) {
                 this.buffer[byteIndex] |= bitMask;
             } else {
@@ -222,14 +176,5 @@ export default class BitField {
             }
         }
         return true;
-    }
-
-    /**
-     * Get the count of bits set to 1.
-     *
-     * @returns The number of bits set to 1.
-     */
-    getSetBitCount(): number {
-        return this.setBitCount;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,12 @@ export default class BitField {
      */
     set(bitIndex: number, value = true): void {
         const byteIndex = bitIndex >> 3;
+        const bitWasSet = this.get(bitIndex);
+
         if (value) {
+            if (!bitWasSet) {
+                this.setBitCount++;
+            }
             if (this.buffer.length < byteIndex + 1) {
                 const length = Math.max(
                     byteIndex + 1,
@@ -90,6 +95,9 @@ export default class BitField {
             // Set
             this.buffer[byteIndex] |= 0b1000_0000 >> bitIndex % 8;
         } else if (byteIndex < this.buffer.length) {
+            if (bitWasSet) {
+                this.setBitCount--;
+            }
             // Clear
             this.buffer[byteIndex] &= ~(0b1000_0000 >> bitIndex % 8);
         }
@@ -116,6 +124,15 @@ export default class BitField {
         let byteIndex = offset >> 3;
         let bitMask = 0b1000_0000 >> offset % 8;
         for (let index = 0; index < array.length; index++) {
+            const bitIndex = offset + index;
+            const bitWasSet = this.get(bitIndex);
+            const bitValue = array[index];
+
+            if (bitValue && !bitWasSet) {
+                this.setBitCount++;
+            } else if (!bitValue && bitWasSet) {
+                this.setBitCount--;
+            }
             if (array[index]) {
                 this.buffer[byteIndex] |= bitMask;
             } else {
@@ -175,5 +192,17 @@ export default class BitField {
             }
         }
         return true;
+    }
+
+    /** Variable to store the count of bits set to 1 */
+    private setBitCount: number = 0;
+
+    /**
+     * Get the count of bits set to 1.
+     *
+     * @returns The number of bits set to 1.
+     */
+    getSetBitCount(): number {
+        return this.setBitCount;
     }
 }


### PR DESCRIPTION
Added isEmpty utility method. Needed a more efficient way to check if a BitField instance has no set bits, using early return for positives.