### PR TITLE
Update comment in constructor to mention bits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export default class BitField {
     /**
      *
      *
-     * @param data Either a number representing the maximum number of supported bytes, or a Uint8Array.
+     * @param data Either a number representing the maximum number of supported bits, or a Uint8Array.
      * @param opts Options for the bitfield.
      */
     constructor(data: number | Uint8Array = 0, options?: BitFieldOptions) {


### PR DESCRIPTION
While the example in README specifies bits, the documentation here specifies bytes, making me think I had to do Math.ceil(.. /8) myself, when the constructor actually takes care of that.